### PR TITLE
記事用にcssを分割するためにhead内のlinkの記述を追加。インデントをタブからスペースに変更

### DIFF
--- a/source/layouts/_head.haml
+++ b/source/layouts/_head.haml
@@ -1,16 +1,16 @@
 %head
-	%meta{ charset: "utf-8" }
-	%meta{ http: { equiv: 'X-UA-Compatible' }, content: 'IE=edge;chrome=1' }
-	%meta{ name: "viewport", content: "width=device-width, initial-scale=1" }
+  %meta{ charset: "utf-8" }
+  %meta{ http: { equiv: 'X-UA-Compatible' }, content: 'IE=edge;chrome=1' }
+  %meta{ name: "viewport", content: "width=device-width, initial-scale=1" }
 
-		- if page_is == "top"
-			%title _blank || top
+    - if page_is == "top"
+      %title _blank || top
 
-		- elsif page_is == "article"
-			%title= "_blank || #{current_page.data.title}"
-			= stylesheet_link_tag "markdown-highlights"
+    - elsif page_is == "article"
+      %title= "_blank || #{current_page.data.title}"
+      = stylesheet_link_tag "markdown-highlights"
 
-	%link{ rel: "shortcut icon", href: "/images/favicon.ico" }
-	= stylesheet_link_tag "reset"
-	= stylesheet_link_tag "common"
-	= javascript_include_tag "http://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js"
+  %link{ rel: "shortcut icon", href: "/images/favicon.ico" }
+  = stylesheet_link_tag "reset"
+  = stylesheet_link_tag "common"
+  = javascript_include_tag "http://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js"

--- a/source/layouts/_head.haml
+++ b/source/layouts/_head.haml
@@ -8,6 +8,7 @@
 
     - elsif page_is == "article"
       %title= "_blank || #{current_page.data.title}"
+      = stylesheet_link_tag "article"
       = stylesheet_link_tag "markdown-highlights"
 
   %link{ rel: "shortcut icon", href: "/images/favicon.ico" }


### PR DESCRIPTION
### やったこと
- head内のstylesheetの記述を追加
- インデントをタブからスペース2つに変更