### PR TITLE
外部リンクのaタグがあった場合、別タブに飛ばすJavaScriptを作成

### DIFF
--- a/source/articles/javascripts/common.js
+++ b/source/articles/javascripts/common.js
@@ -1,0 +1,14 @@
+var MOYASHI = MOYASHI || {};
+
+MOYASHI.LINK = {
+  init : function(){
+    this.bindEvent();
+  },
+  bindEvent : function(){
+    $('a[href^="http://"], a[href^="https://"]').attr('target', '_blank');
+  }
+}
+
+$(function(){
+  MOYASHI.LINK.init();
+})


### PR DESCRIPTION
### やったこと
- aタグのhrefがhttp://,https://から始まる場合、別タブに飛ばすように_blankを追加する